### PR TITLE
Add PowerDNS support

### DIFF
--- a/pdns/pdns.go
+++ b/pdns/pdns.go
@@ -4,6 +4,7 @@ package pdns
 
 import (
 	"errors"
+	"net/url"
 
 	"github.com/mholt/caddy/caddytls"
 	"github.com/xenolf/lego/providers/dns/pdns"
@@ -23,7 +24,11 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return pdns.NewDNSProvider()
 	case 2:
-		return pdns.NewDNSProviderCredentials(credentials[0], credentials[1])
+		url, err := url.Parse(credentials[0])
+		if err != nil {
+			return nil, errors.New("Invalid URL format")
+		}
+		return pdns.NewDNSProviderCredentials(url, credentials[1])
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/pdns/pdns.go
+++ b/pdns/pdns.go
@@ -1,0 +1,30 @@
+// Package pdns adapts the lego PowerDNS
+// provider for Caddy. Importing this package plugs it in.
+package pdns
+
+import (
+	"errors"
+
+	"github.com/mholt/caddy/caddytls"
+	"github.com/xenolf/lego/providers/dns/pdns"
+)
+
+func init() {
+	caddytls.RegisterDNSProvider("powerdns", NewDNSProvider)
+}
+
+// NewDNSProvider returns a new PowerDNS challenge provider.
+// The credentials are interpreted as follows:
+//
+// len(0): use credentials from environment
+// len(2): credentials[0] = pdns API URL, credentials[1] = pdns API key
+func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
+	switch len(credentials) {
+	case 0:
+		return pdns.NewDNSProvider()
+	case 2:
+		return pdns.NewDNSProviderCredentials(credentials[0], credentials[1])
+	default:
+		return nil, errors.New("invalid credentials length")
+	}
+}


### PR DESCRIPTION
Noticed the other pull request to add PowerDNS support was abandoned; I've created my own pull request with the changes you requested from the other.

Tested using `PDNS_API_KEY`, `PDNS_API_URL` env vars, and the following statement in a Caddyfile:

```
	tls {
		dns powerdns
	}
```