### PR TITLE
Use new dnsprovider constructors

### DIFF
--- a/auroradns/auroradns.go
+++ b/auroradns/auroradns.go
@@ -25,7 +25,11 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return auroradns.NewDNSProvider()
 	case 3:
-		return auroradns.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2])
+		config := auroradns.NewDefaultConfig()
+		config.BaseURL = credentials[0]
+		config.UserID = credentials[1]
+		config.Key = credentials[2]
+		return auroradns.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/cloudflare/cloudflare.go
+++ b/cloudflare/cloudflare.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return cloudflare.NewDNSProvider()
 	case 2:
-		return cloudflare.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := cloudflare.NewDefaultConfig()
+		config.AuthEmail = credentials[0]
+		config.AuthKey = credentials[1]
+		return cloudflare.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/cloudxns/cloudxns.go
+++ b/cloudxns/cloudxns.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return cloudxns.NewDNSProvider()
 	case 2:
-		return cloudxns.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := cloudxns.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		config.SecretKey = credentials[1]
+		return cloudxns.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/digitalocean/digitalocean.go
+++ b/digitalocean/digitalocean.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return digitalocean.NewDNSProvider()
 	case 1:
-		return digitalocean.NewDNSProviderCredentials(credentials[0])
+		config := digitalocean.NewDefaultConfig()
+		config.AuthToken = credentials[0]
+		return digitalocean.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/dnsimple/dnsimple.go
+++ b/dnsimple/dnsimple.go
@@ -24,7 +24,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return dnsimple.NewDNSProvider()
 	case 2:
-		return dnsimple.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := dnsimple.NewDefaultConfig()
+		config.AccessToken = credentials[1]
+		return dnsimple.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/dnsmadeeasy/dnsmadeeasy.go
+++ b/dnsmadeeasy/dnsmadeeasy.go
@@ -25,7 +25,11 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return dnsmadeeasy.NewDNSProvider()
 	case 3:
-		return dnsmadeeasy.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2])
+		config := dnsmadeeasy.NewDefaultConfig()
+		config.BaseURL = credentials[0]
+		config.APIKey = credentials[1]
+		config.APISecret = credentials[2]
+		return dnsmadeeasy.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/dnspod/dnspod.go
+++ b/dnspod/dnspod.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return dnspod.NewDNSProvider()
 	case 1:
-		return dnspod.NewDNSProviderCredentials(credentials[0])
+		config := dnspod.NewDefaultConfig()
+		config.LoginToken = credentials[0]
+		return dnspod.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/duckdns/duckdns.go
+++ b/duckdns/duckdns.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return duckdns.NewDNSProvider()
 	case 1:
-		return duckdns.NewDNSProviderCredentials(credentials[0])
+		config := duckdns.NewDefaultConfig()
+		config.Token = credentials[0]
+		return duckdns.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/dyn/dyn.go
+++ b/dyn/dyn.go
@@ -25,7 +25,11 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return dyn.NewDNSProvider()
 	case 3:
-		return dyn.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2])
+		config := dyn.NewDefaultConfig()
+		config.CustomerName = credentials[0]
+		config.UserName = credentials[1]
+		config.Password = credentials[2]
+		return dyn.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/exoscale/exoscale.go
+++ b/exoscale/exoscale.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return exoscale.NewDNSProvider()
 	case 2:
-		return exoscale.NewDNSProviderClient(credentials[0], credentials[1], "")
+		config := exoscale.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		config.APISecret = credentials[1]
+		return exoscale.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/fastdns/fastdns.go
+++ b/fastdns/fastdns.go
@@ -26,7 +26,12 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return fastdns.NewDNSProvider()
 	case 4:
-		return fastdns.NewDNSProviderClient(credentials[0], credentials[1], credentials[2], credentials[3])
+		config := fastdns.NewDefaultConfig()
+		config.Config.Host = credentials[0]
+		config.Config.ClientToken = credentials[1]
+		config.Config.ClientSecret = credentials[2]
+		config.Config.AccessToken = credentials[3]
+		return fastdns.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/gandi/gandi.go
+++ b/gandi/gandi.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return gandi.NewDNSProvider()
 	case 1:
-		return gandi.NewDNSProviderCredentials(credentials[0])
+		config := gandi.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		return gandi.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/gandiv5/gandiv5.go
+++ b/gandiv5/gandiv5.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return gandiv5.NewDNSProvider()
 	case 1:
-		return gandiv5.NewDNSProviderCredentials(credentials[0])
+		config := gandiv5.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		return gandiv5.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/generic/generic.go
+++ b/generic/generic.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return exec.NewDNSProvider()
 	case 1:
-		return exec.NewDNSProviderProgram(credentials[0])
+		config := exec.NewDefaultConfig()
+		config.Program = credentials[0]
+		return exec.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/glesys/glesys.go
+++ b/glesys/glesys.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return glesys.NewDNSProvider()
 	case 2:
-		return glesys.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := glesys.NewDefaultConfig()
+		config.APIUser = credentials[0]
+		config.APIKey = credentials[1]
+		return glesys.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/godaddy/godaddy.go
+++ b/godaddy/godaddy.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return godaddy.NewDNSProvider()
 	case 2:
-		return godaddy.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := godaddy.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		config.APISecret = credentials[1]
+		return godaddy.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/googlecloud/googlecloud.go
+++ b/googlecloud/googlecloud.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return gcloud.NewDNSProvider()
 	case 1:
-		return gcloud.NewDNSProviderCredentials(credentials[0])
+		config := gcloud.NewDefaultConfig()
+		config.Project = credentials[0]
+		return gcloud.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/linode/linode.go
+++ b/linode/linode.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return linode.NewDNSProvider()
 	case 1:
-		return linode.NewDNSProviderCredentials(credentials[0])
+		config := linode.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		return linode.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/namecheap/namecheap.go
+++ b/namecheap/namecheap.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return namecheap.NewDNSProvider()
 	case 2:
-		return namecheap.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := namecheap.NewDefaultConfig()
+		config.APIUser = credentials[0]
+		config.APIKey = credentials[1]
+		return namecheap.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/namedotcom/namedotcom.go
+++ b/namedotcom/namedotcom.go
@@ -23,13 +23,18 @@ func init() {
 //         credentials[1] = API token
 //         credentials[2] = Server
 func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
+	config := namedotcom.NewDefaultConfig()
+
 	switch len(credentials) {
 	case 0:
 		return namedotcom.NewDNSProvider()
-	case 2:
-		return namedotcom.NewDNSProviderCredentials(credentials[0], credentials[1], "")
 	case 3:
-		return namedotcom.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2])
+		config.Server = credentials[2]
+		fallthrough
+	case 2:
+		config.Username = credentials[0]
+		config.APIToken = credentials[1]
+		return namedotcom.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/ns1/ns1.go
+++ b/ns1/ns1.go
@@ -16,13 +16,14 @@ func init() {
 //
 // len(0): use credentials from environment
 // len(1): credentials[0] = API key
-
 func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	switch len(credentials) {
 	case 0:
 		return ns1.NewDNSProvider()
 	case 1:
-		return ns1.NewDNSProviderCredentials(credentials[0])
+		config := ns1.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		return ns1.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/otc/otc.go
+++ b/otc/otc.go
@@ -27,7 +27,13 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return otc.NewDNSProvider()
 	case 5:
-		return otc.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2], credentials[3], credentials[4])
+		config := otc.NewDefaultConfig()
+		config.DomainName = credentials[0]
+		config.UserName = credentials[1]
+		config.Password = credentials[2]
+		config.ProjectName = credentials[3]
+		config.IdentityEndpoint = credentials[4]
+		return otc.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/ovh/ovh.go
+++ b/ovh/ovh.go
@@ -26,7 +26,12 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return ovh.NewDNSProvider()
 	case 4:
-		return ovh.NewDNSProviderCredentials(credentials[0], credentials[1], credentials[2], credentials[3])
+		config := ovh.NewDefaultConfig()
+		config.APIEndpoint = credentials[0]
+		config.ApplicationKey = credentials[1]
+		config.ApplicationSecret = credentials[2]
+		config.ConsumerKey = credentials[3]
+		return ovh.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/pdns/pdns.go
+++ b/pdns/pdns.go
@@ -24,11 +24,14 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return pdns.NewDNSProvider()
 	case 2:
-		url, err := url.Parse(credentials[0])
+		var err error
+		config := pdns.NewDefaultConfig()
+		config.Host, err = url.Parse(credentials[0])
 		if err != nil {
-			return nil, errors.New("Invalid URL format")
+			return nil, errors.New("invalid URL format")
 		}
-		return pdns.NewDNSProviderCredentials(url, credentials[1])
+		config.APIKey = credentials[1]
+		return pdns.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/rackspace/rackspace.go
+++ b/rackspace/rackspace.go
@@ -24,7 +24,10 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return rackspace.NewDNSProvider()
 	case 2:
-		return rackspace.NewDNSProviderCredentials(credentials[0], credentials[1])
+		config := rackspace.NewDefaultConfig()
+		config.APIUser = credentials[0]
+		config.APIKey = credentials[1]
+		return rackspace.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}

--- a/vultr/vultr.go
+++ b/vultr/vultr.go
@@ -23,7 +23,9 @@ func NewDNSProvider(credentials ...string) (caddytls.ChallengeProvider, error) {
 	case 0:
 		return vultr.NewDNSProvider()
 	case 1:
-		return vultr.NewDNSProviderCredentials(credentials[0])
+		config := vultr.NewDefaultConfig()
+		config.APIKey = credentials[0]
+		return vultr.NewDNSProviderConfig(config)
 	default:
 		return nil, errors.New("invalid credentials length")
 	}


### PR DESCRIPTION
`github.com/xenolf/lego/providers/dns/digitalocean` was recently refactored and the `NewDNSProviderCredentials()` constructor has been supplanted with one that expects a config object.